### PR TITLE
feat: retry logic — max_retries, exponential backoff, per-attempt DB rows

### DIFF
--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,272 @@
+"""Tests for retry logic in step() — max_retries and exponential backoff.
+
+Acceptance criteria (issue #5):
+- A step that fails twice then succeeds: 3 rows in step_records, run completes.
+- Backoff timing is respected (tested with a mock sleep).
+- All retries exhausted: original exception propagates.
+- status() shows all attempt rows for a retried step.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from workflow.step import reset_current_run, set_current_run, step
+from workflow.store import WorkflowStore
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> WorkflowStore:
+    s = WorkflowStore(db_path=tmp_path / "test.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def run_ctx(store: WorkflowStore):
+    run_id = store.create_run("test_workflow")
+    token = set_current_run(store, run_id)
+    yield store, run_id
+    reset_current_run(token)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_flaky(fail_times: int):
+    """Return a function that raises ValueError the first *fail_times* calls,
+    then returns 'ok'."""
+    state = {"calls": 0}
+
+    def fn() -> str:
+        state["calls"] += 1
+        if state["calls"] <= fail_times:
+            raise ValueError(f"transient failure #{state['calls']}")
+        return "ok"
+
+    fn.state = state  # type: ignore[attr-defined]
+    return fn
+
+
+# ---------------------------------------------------------------------------
+# Basic retry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRetrySuccess:
+    def test_fail_twice_succeed_third_creates_three_rows(self, run_ctx, tmp_path) -> None:
+        """Acceptance criterion: step fails twice then succeeds → 3 step_records rows."""
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=2)
+
+        with patch("workflow.step.time.sleep"):  # skip actual delays
+            result = step("s", flaky, max_retries=2, base_delay=0.0)
+
+        assert result == "ok"
+        assert flaky.state["calls"] == 3
+
+        rows = store.get_steps(run_id)
+        assert len(rows) == 3
+        assert rows[0].status == "failed"
+        assert rows[1].status == "failed"
+        assert rows[2].status == "completed"
+        assert rows[0].attempt == 0
+        assert rows[1].attempt == 1
+        assert rows[2].attempt == 2
+
+    def test_fail_once_succeed_second(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=1)
+
+        with patch("workflow.step.time.sleep"):
+            result = step("s", flaky, max_retries=1, base_delay=0.0)
+
+        assert result == "ok"
+        rows = store.get_steps(run_id)
+        assert len(rows) == 2
+        assert rows[0].status == "failed"
+        assert rows[1].status == "completed"
+
+    def test_no_retries_needed_single_row(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        result = step("s", lambda: 42, max_retries=3)
+        rows = store.get_steps(run_id)
+        assert len(rows) == 1
+        assert rows[0].status == "completed"
+        assert result == 42
+
+    def test_run_completes_after_retries(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=1)
+
+        with patch("workflow.step.time.sleep"):
+            step("s", flaky, max_retries=2, base_delay=0.0)
+
+        # The run itself is marked completed by the engine; but the step record
+        # should show "completed" on the last attempt.
+        rows = store.get_steps(run_id)
+        assert rows[-1].status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Exhausted retries
+# ---------------------------------------------------------------------------
+
+
+class TestRetryExhausted:
+    def test_all_retries_exhausted_raises(self, run_ctx) -> None:
+        flaky = make_flaky(fail_times=99)  # never succeeds
+
+        with patch("workflow.step.time.sleep"):
+            with pytest.raises(ValueError, match="transient failure"):
+                step("s", flaky, max_retries=2, base_delay=0.0)
+
+    def test_all_retries_exhausted_creates_correct_rows(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=99)
+
+        with patch("workflow.step.time.sleep"):
+            with pytest.raises(ValueError):
+                step("s", flaky, max_retries=2, base_delay=0.0)
+
+        rows = store.get_steps(run_id)
+        assert len(rows) == 3  # attempt 0, 1, 2 — all failed
+        assert all(r.status == "failed" for r in rows)
+        assert rows[-1].attempt == 2
+
+    def test_zero_retries_raises_immediately(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=99)
+
+        with pytest.raises(ValueError):
+            step("s", flaky, max_retries=0)
+
+        rows = store.get_steps(run_id)
+        assert len(rows) == 1
+        assert rows[0].status == "failed"
+        assert rows[0].attempt == 0
+
+    def test_error_message_stored_on_each_attempt(self, run_ctx) -> None:
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=99)
+
+        with patch("workflow.step.time.sleep"):
+            with pytest.raises(ValueError):
+                step("s", flaky, max_retries=1, base_delay=0.0)
+
+        rows = store.get_steps(run_id)
+        for row in rows:
+            assert row.error is not None
+            assert "ValueError" in row.error
+
+
+# ---------------------------------------------------------------------------
+# Backoff timing
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffTiming:
+    def test_backoff_calls_sleep_with_correct_delays(self, run_ctx) -> None:
+        """sleep is called with base_delay * 2**attempt for each retry."""
+        flaky = make_flaky(fail_times=2)
+        sleep_calls: list[float] = []
+
+        def record_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        with patch("workflow.step.time.sleep", side_effect=record_sleep):
+            step("s", flaky, max_retries=2, base_delay=1.0)
+
+        # attempt 0 fails → sleep 1.0 * 2^0 = 1.0
+        # attempt 1 fails → sleep 1.0 * 2^1 = 2.0
+        # attempt 2 succeeds → no sleep
+        assert sleep_calls == [1.0, 2.0]
+
+    def test_custom_base_delay(self, run_ctx) -> None:
+        flaky = make_flaky(fail_times=1)
+        sleep_calls: list[float] = []
+
+        with patch("workflow.step.time.sleep", side_effect=lambda s: sleep_calls.append(s)):
+            step("s", flaky, max_retries=1, base_delay=0.5)
+
+        assert sleep_calls == [0.5]  # 0.5 * 2^0
+
+    def test_no_sleep_when_no_retries(self, run_ctx) -> None:
+        with patch("workflow.step.time.sleep") as mock_sleep:
+            step("s", lambda: "ok", max_retries=0)
+        mock_sleep.assert_not_called()
+
+    def test_no_sleep_on_success_first_try(self, run_ctx) -> None:
+        with patch("workflow.step.time.sleep") as mock_sleep:
+            step("s", lambda: "ok", max_retries=3, base_delay=1.0)
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency still works with retries
+# ---------------------------------------------------------------------------
+
+
+class TestRetryIdempotency:
+    def test_completed_step_not_retried(self, run_ctx) -> None:
+        """A COMPLETED step is still a cache hit even when max_retries > 0."""
+        store, run_id = run_ctx
+        call_count = {"n": 0}
+
+        def fn() -> str:
+            call_count["n"] += 1
+            return "done"
+
+        step("s", fn, max_retries=3)
+        step("s", fn, max_retries=3)  # should be a cache hit
+
+        assert call_count["n"] == 1
+        assert len(store.get_steps(run_id)) == 1
+
+    def test_input_hash_consistent_across_retries(self, run_ctx) -> None:
+        """All retry attempts share the same input_hash."""
+        store, run_id = run_ctx
+        flaky = make_flaky(fail_times=1)
+
+        with patch("workflow.step.time.sleep"):
+            step("s", flaky, max_retries=1, base_delay=0.0)
+
+        rows = store.get_steps(run_id)
+        hashes = {r.input_hash for r in rows}
+        assert len(hashes) == 1  # same hash on all attempts
+
+
+# ---------------------------------------------------------------------------
+# status() shows all attempt rows
+# ---------------------------------------------------------------------------
+
+
+class TestStatusShowsAttempts:
+    def test_status_all_attempts_visible(self, tmp_path: Path) -> None:
+        from workflow.engine import WorkflowEngine
+
+        flaky = make_flaky(fail_times=2)
+
+        with WorkflowEngine(db_path=tmp_path / "e.db") as engine:
+            def wf() -> None:
+                with patch("workflow.step.time.sleep"):
+                    step("flaky_step", flaky, max_retries=2, base_delay=0.0)
+
+            run_id = engine.run(wf)
+            status = engine.status(run_id)
+
+        step_rows = [s for s in status.steps if s.step_name == "flaky_step"]
+        assert len(step_rows) == 3
+        statuses = [r.status for r in step_rows]
+        assert statuses == ["failed", "failed", "completed"]

--- a/workflow/step.py
+++ b/workflow/step.py
@@ -10,7 +10,13 @@ How it works
 3. Write a RUNNING record to the store (durability checkpoint *before* work).
 4. Call ``func(*args, **kwargs)``.
 5. On success  → write COMPLETED + ``pickle.dumps(result)`` → return result.
-6. On exception → write FAILED + error message → re-raise.
+6. On exception → write FAILED + error message.
+   - If ``attempt < max_retries``: sleep ``base_delay * 2 ** attempt`` seconds,
+     increment attempt, go to step 3.
+   - Otherwise: re-raise the original exception.
+
+Each retry is a **new row** in ``step_records`` with an incremented ``attempt``
+number so the full history is always inspectable via ``status()``.
 
 The current ``run_id`` is picked up transparently from a ``ContextVar`` so
 callers never have to thread it through manually.
@@ -20,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import pickle
+import time
 import traceback
 from collections.abc import Callable
 from contextvars import ContextVar
@@ -94,14 +101,26 @@ def _compute_input_hash(*args: Any, **kwargs: Any) -> str:
 # ---------------------------------------------------------------------------
 
 
-def step(name: str, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+def step(
+    name: str,
+    func: Callable[..., T],
+    *args: Any,
+    max_retries: int = 0,
+    base_delay: float = 1.0,
+    **kwargs: Any,
+) -> T:
     """Execute *func* as a durable, idempotent workflow step.
 
     Args:
-        name:   Logical name for this step (must be unique within a workflow).
-        func:   The callable to execute.
-        *args:  Positional arguments forwarded to *func*.
-        **kwargs: Keyword arguments forwarded to *func*.
+        name:        Logical name for this step (must be unique within a workflow).
+        func:        The callable to execute.
+        *args:       Positional arguments forwarded to *func*.
+        max_retries: Number of additional attempts after the first failure.
+                     ``0`` means no retries (default).  Total attempts = ``max_retries + 1``.
+        base_delay:  Base sleep time in seconds for exponential backoff.
+                     Attempt *k* sleeps ``base_delay * 2 ** k`` seconds before
+                     retrying (k=0 on first retry, k=1 on second, …).
+        **kwargs:    Keyword arguments forwarded to *func*.
 
     Returns:
         The return value of ``func(*args, **kwargs)`` — either freshly computed
@@ -109,7 +128,8 @@ def step(name: str, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
 
     Raises:
         RuntimeError: if called outside a workflow execution context.
-        Exception:    Whatever *func* raises, after recording FAILED in the store.
+        Exception:    Whatever *func* raises on the final attempt, after all
+                      retries are exhausted.
     """
     store, run_id = get_current_run()
     input_hash = _compute_input_hash(*args, **kwargs)
@@ -120,33 +140,45 @@ def step(name: str, func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         # Cache hit: return the previously stored result without re-executing.
         return pickle.loads(existing.output)  # type: ignore[return-value]
 
-    # --- 2. Determine attempt number ------------------------------------------
+    # --- 2. Determine starting attempt number ---------------------------------
+    # Resume after a prior failure: pick up where we left off.
     attempt = 0 if existing is None else existing.attempt + 1
 
-    # --- 3. Write RUNNING checkpoint (before execution) -----------------------
-    store.write_step(run_id, name, attempt=attempt, status="running", input_hash=input_hash)
+    # --- 3-6. Execute with retry loop -----------------------------------------
+    while True:
+        # Checkpoint RUNNING before doing any work.
+        store.write_step(run_id, name, attempt=attempt, status="running", input_hash=input_hash)
 
-    # --- 4 & 5. Execute and persist result ------------------------------------
-    try:
-        result: T = func(*args, **kwargs)
-    except Exception as exc:
-        # --- 6. Persist failure and propagate ---------------------------------
+        try:
+            result: T = func(*args, **kwargs)
+        except Exception:
+            error_text = traceback.format_exc()
+            store.write_step(
+                run_id,
+                name,
+                attempt=attempt,
+                status="failed",
+                input_hash=input_hash,
+                error=error_text,
+            )
+
+            retries_remaining = max_retries - attempt
+            if retries_remaining > 0:
+                # Exponential backoff before next attempt.
+                delay = base_delay * (2 ** attempt)
+                time.sleep(delay)
+                attempt += 1
+                continue  # retry
+            else:
+                raise  # all attempts exhausted — propagate
+
+        # Success
         store.write_step(
             run_id,
             name,
             attempt=attempt,
-            status="failed",
+            status="completed",
             input_hash=input_hash,
-            error=traceback.format_exc(),
+            output=pickle.dumps(result),
         )
-        raise
-
-    store.write_step(
-        run_id,
-        name,
-        attempt=attempt,
-        status="completed",
-        input_hash=input_hash,
-        output=pickle.dumps(result),
-    )
-    return result
+        return result


### PR DESCRIPTION
## Summary

Implements issue #5 — transient step failures now retry automatically with exponential backoff.

## API change

```python
# Before (still works — defaults unchanged)
result = step('fetch', download_audio, episode_id)

# With retries
result = step('fetch', download_audio, episode_id,
              max_retries=3, base_delay=1.0)
# Attempt 0 fails → sleep 1.0s
# Attempt 1 fails → sleep 2.0s
# Attempt 2 fails → sleep 4.0s
# Attempt 3 succeeds → return result
```

## Changes

### `workflow/step.py`

New parameters on `step()`:
- `max_retries: int = 0` — number of *additional* attempts after first failure; 0 = no retry
- `base_delay: float = 1.0` — base sleep seconds; attempt *k* sleeps `base_delay × 2ᵏ`

Implementation:
- Single `while True` retry loop replaces the previous try/except
- Each attempt writes a RUNNING checkpoint **before** executing (durability preserved)
- On failure: writes FAILED row, checks `retries_remaining`; if > 0 sleeps and loops; otherwise re-raises
- On success: writes COMPLETED row, returns result
- Idempotency unchanged: a COMPLETED step with matching `input_hash` is still a cache hit regardless of `max_retries`
- All retry attempts share the same `input_hash` (inputs didn't change between retries)

### `tests/test_retry.py` — 15 tests

| Class | Coverage |
|---|---|
| `TestRetrySuccess` | fail×2 succeed×1 → 3 rows ✅ (acceptance criterion), fail×1 succeed×1, no retries needed, run completes |
| `TestRetryExhausted` | raises after all retries, correct row count, zero retries raises immediately, error stored per attempt |
| `TestBackoffTiming` | sleep called with `[1.0, 2.0]` for `base_delay=1.0`, custom base_delay, no sleep on success, no sleep with zero retries |
| `TestRetryIdempotency` | completed step still a cache hit with `max_retries>0`, input_hash consistent across attempts |
| `TestStatusShowsAttempts` | engine integration: `status()` returns all 3 attempt rows |

## Acceptance criteria

- [x] Step fails twice then succeeds: **3 rows** in `step_records`, run completes successfully
- [x] Backoff timing: `sleep` called with correct `base_delay * 2**attempt` values
- [x] All retries exhausted: original exception propagates
- [x] `status()` shows all attempts with timing

Full suite: **78/78 passed**, 0 warnings.

Closes #5