### PR TITLE
feat: CLI — wf run/status/resume/runs list/runs inspect

### DIFF
--- a/examples/podcast_pipeline.py
+++ b/examples/podcast_pipeline.py
@@ -1,52 +1,65 @@
 """Example: 4-step podcast processing workflow.
 
-This example will be wired up to the real engine in a future issue.
-For now it shows the intended API shape.
-
-Usage (once the engine is implemented):
+Usage:
     uv run wf run examples/podcast_pipeline.py --episode-id ep-123
+    uv run wf runs list
+    uv run wf status <run_id>
+    uv run wf resume <run_id>
 """
 
-# from workflow import workflow, step, WorkflowEngine
+from workflow.engine import WorkflowEngine
+from workflow.step import step
+
+
+# ---------------------------------------------------------------------------
+# Step functions (pure — no engine awareness)
+# ---------------------------------------------------------------------------
 
 
 def download_audio(episode_id: str) -> str:
     """Simulate downloading an audio file. Returns local path."""
-    print(f"[download_audio] episode={episode_id}")
+    print(f"  [download_audio] episode={episode_id}")
     return f"/tmp/{episode_id}.mp3"
 
 
 def transcribe_audio(audio_path: str) -> str:
     """Simulate transcription. Returns transcript text."""
-    print(f"[transcribe_audio] path={audio_path}")
+    print(f"  [transcribe_audio] path={audio_path}")
     return "This is the transcript of the episode."
 
 
 def summarize_text(transcript: str) -> str:
     """Simulate summarisation. Returns a short summary."""
-    print(f"[summarize_text] chars={len(transcript)}")
+    print(f"  [summarize_text] chars={len(transcript)}")
     return "Short summary of the episode."
 
 
 def export_to_db(episode_id: str, summary: str) -> bool:
     """Simulate writing the summary to a database."""
-    print(f"[export_to_db] episode={episode_id} summary={summary!r}")
+    print(f"  [export_to_db] episode={episode_id} summary={summary!r}")
     return True
 
 
-# @workflow
-# def process_podcast(episode_id: str):
-#     audio_path  = step("download",    download_audio,   episode_id)
-#     transcript  = step("transcribe",  transcribe_audio, audio_path)
-#     summary     = step("summarize",   summarize_text,   transcript)
-#     return       step("export",       export_to_db,     episode_id, summary)
+# ---------------------------------------------------------------------------
+# Workflow function
+# ---------------------------------------------------------------------------
 
 
-if __name__ == "__main__":
-    # Placeholder: run the steps sequentially (no durability yet)
-    episode_id = "ep-123"
-    audio_path = download_audio(episode_id)
-    transcript = transcribe_audio(audio_path)
-    summary = summarize_text(transcript)
-    result = export_to_db(episode_id, summary)
-    print(f"Done: {result}")
+def process_podcast(episode_id: str) -> bool:
+    audio_path = step("download", download_audio, episode_id)
+    transcript = step("transcribe", transcribe_audio, audio_path)
+    summary    = step("summarize", summarize_text, transcript)
+    return       step("export", export_to_db, episode_id, summary)
+
+
+# ---------------------------------------------------------------------------
+# CLI discovery hook — the wf CLI looks for WORKFLOW and INPUT_SCHEMA
+# ---------------------------------------------------------------------------
+
+#: The function the engine should run.
+WORKFLOW = process_podcast
+
+#: Declares expected CLI flags (name → Python type).  Used by ``wf run``.
+INPUT_SCHEMA: dict[str, type] = {
+    "episode_id": str,
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,333 @@
+"""Tests for the wf CLI — all commands via Click's test runner.
+
+Acceptance criteria (issue #7):
+- wf run executes a workflow and prints a run_id.
+- wf status shows per-step table with timing.
+- wf resume resumes a failed run and marks it completed.
+- wf runs list shows recent runs colour-coded by status.
+- wf runs inspect shows the full step-by-step trace.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from workflow.cli import cli
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> str:
+    return str(tmp_path / "test.db")
+
+
+@pytest.fixture
+def simple_wf_file(tmp_path: Path) -> str:
+    """A .py file with a WORKFLOW that runs 3 steps and succeeds."""
+    p = tmp_path / "simple_wf.py"
+    p.write_text(textwrap.dedent("""\
+        from workflow.step import step
+
+        def simple_workflow(label: str) -> str:
+            a = step("step_a", lambda l: f"a_{l}", label)
+            b = step("step_b", lambda v: v.upper(), a)
+            return step("step_c", lambda v: f"done:{v}", b)
+
+        WORKFLOW = simple_workflow
+        INPUT_SCHEMA = {"label": str}
+    """))
+    return str(p)
+
+
+@pytest.fixture
+def crashing_wf_file(tmp_path: Path) -> str:
+    """A .py file whose step_b always crashes."""
+    p = tmp_path / "crash_wf.py"
+    p.write_text(textwrap.dedent("""\
+        from workflow.step import step
+
+        def crash_workflow(label: str) -> str:
+            a = step("step_a", lambda l: f"a_{l}", label)
+            def boom(v):
+                raise RuntimeError("boom!")
+            b = step("step_b", boom, a)
+            return step("step_c", lambda v: v, b)
+
+        WORKFLOW = crash_workflow
+        INPUT_SCHEMA = {"label": str}
+    """))
+    return str(p)
+
+
+@pytest.fixture
+def fixed_wf_file(tmp_path: Path) -> str:
+    """Same workflow as crashing_wf_file but step_b is fixed."""
+    p = tmp_path / "fixed_wf.py"
+    p.write_text(textwrap.dedent("""\
+        from workflow.step import step
+
+        def crash_workflow(label: str) -> str:
+            a = step("step_a", lambda l: f"a_{l}", label)
+            b = step("step_b", lambda v: f"fixed_{v}", a)
+            return step("step_c", lambda v: v, b)
+
+        WORKFLOW = crash_workflow
+        INPUT_SCHEMA = {"label": str}
+    """))
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _run_id_from_output(output: str) -> str:
+    """Extract the uuid4 run_id from wf run output."""
+    for token in output.split():
+        token = token.strip(".")
+        if len(token) == 36 and token.count("-") == 4:
+            return token
+    raise ValueError(f"No run_id found in:\n{output}")
+
+
+# ---------------------------------------------------------------------------
+# wf run
+# ---------------------------------------------------------------------------
+
+
+class TestCliRun:
+    def test_run_succeeds(self, runner, db, simple_wf_file) -> None:
+        result = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        assert result.exit_code == 0, result.output
+        assert "Completed" in result.output
+
+    def test_run_prints_run_id(self, runner, db, simple_wf_file) -> None:
+        result = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        assert result.exit_code == 0
+        run_id = _run_id_from_output(result.output)
+        assert len(run_id) == 36
+
+    def test_run_missing_workflow_var(self, runner, db, tmp_path) -> None:
+        p = tmp_path / "no_wf.py"
+        p.write_text("x = 1\n")
+        result = runner.invoke(cli, ["run", str(p), "--db", db])
+        assert result.exit_code != 0
+        assert "WORKFLOW" in result.output
+
+    def test_run_nonexistent_file(self, runner, db) -> None:
+        result = runner.invoke(cli, ["run", "/does/not/exist.py", "--db", db])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()
+
+    def test_run_failed_workflow_exits_nonzero(self, runner, db, crashing_wf_file) -> None:
+        result = runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        assert result.exit_code != 0
+        assert "failed" in result.output.lower()
+
+    def test_run_kebab_flag_converted_to_underscore(self, runner, db, tmp_path) -> None:
+        p = tmp_path / "kw_wf.py"
+        p.write_text(textwrap.dedent("""\
+            from workflow.step import step
+            def kw_workflow(my_key: str) -> str:
+                return step("s", lambda v: v, my_key)
+            WORKFLOW = kw_workflow
+            INPUT_SCHEMA = {"my_key": str}
+        """))
+        result = runner.invoke(cli, ["run", str(p), "--my-key", "val", "--db", db])
+        assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
+# wf status
+# ---------------------------------------------------------------------------
+
+
+class TestCliStatus:
+    def test_status_shows_completed(self, runner, db, simple_wf_file) -> None:
+        r = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        run_id = _run_id_from_output(r.output)
+        result = runner.invoke(cli, ["status", run_id, "--db", db])
+        assert result.exit_code == 0
+        assert "completed" in result.output
+
+    def test_status_shows_all_step_names(self, runner, db, simple_wf_file) -> None:
+        r = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        run_id = _run_id_from_output(r.output)
+        result = runner.invoke(cli, ["status", run_id, "--db", db])
+        assert "step_a" in result.output
+        assert "step_b" in result.output
+        assert "step_c" in result.output
+
+    def test_status_shows_timing(self, runner, db, simple_wf_file) -> None:
+        r = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        run_id = _run_id_from_output(r.output)
+        result = runner.invoke(cli, ["status", run_id, "--db", db])
+        # Duration column header present
+        assert "DURATION" in result.output
+
+    def test_status_unknown_run_id(self, runner, db) -> None:
+        result = runner.invoke(cli, ["status", "no-such-id", "--db", db])
+        assert result.exit_code != 0
+
+    def test_status_failed_step_shows_error(self, runner, db, crashing_wf_file) -> None:
+        runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        from workflow.engine import WorkflowEngine
+        with WorkflowEngine(db_path=db) as eng:
+            runs = eng.store.list_runs(limit=1)
+        run_id = runs[0].id
+        result = runner.invoke(cli, ["status", run_id, "--db", db])
+        assert "failed" in result.output
+        assert "boom" in result.output
+
+
+# ---------------------------------------------------------------------------
+# wf resume
+# ---------------------------------------------------------------------------
+
+
+class TestCliResume:
+    def _get_failed_run_id(self, runner, db, crashing_wf_file) -> str:
+        runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        from workflow.engine import WorkflowEngine
+        with WorkflowEngine(db_path=db) as eng:
+            runs = eng.store.list_runs(limit=1)
+        return runs[0].id
+
+    def test_resume_completes_run(self, runner, db, crashing_wf_file, fixed_wf_file) -> None:
+        run_id = self._get_failed_run_id(runner, db, crashing_wf_file)
+        result = runner.invoke(
+            cli, ["resume", run_id, "--db", db, "--workflow-file", fixed_wf_file]
+        )
+        assert result.exit_code == 0, result.output
+        assert "Completed" in result.output
+
+    def test_resume_without_file_raises(self, runner, db, crashing_wf_file) -> None:
+        run_id = self._get_failed_run_id(runner, db, crashing_wf_file)
+        # No --workflow-file → engine has no registered function.
+        result = runner.invoke(cli, ["resume", run_id, "--db", db])
+        assert result.exit_code != 0
+        assert "registered" in result.output
+
+    def test_resume_unknown_run_id(self, runner, db) -> None:
+        result = runner.invoke(cli, ["resume", "no-such-id", "--db", db])
+        assert result.exit_code != 0
+
+    def test_resume_skips_completed_steps(self, runner, db, crashing_wf_file, fixed_wf_file) -> None:
+        run_id = self._get_failed_run_id(runner, db, crashing_wf_file)
+        runner.invoke(cli, ["resume", run_id, "--db", db, "--workflow-file", fixed_wf_file])
+        from workflow.engine import WorkflowEngine
+        with WorkflowEngine(db_path=db) as eng:
+            steps = eng.store.get_steps(run_id)
+        # step_a was completed before crash — still only 1 row for it.
+        step_a_rows = [s for s in steps if s.step_name == "step_a"]
+        assert len(step_a_rows) == 1
+        assert step_a_rows[0].status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# wf runs list
+# ---------------------------------------------------------------------------
+
+
+class TestCliRunsList:
+    def test_runs_list_shows_run(self, runner, db, simple_wf_file) -> None:
+        runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        result = runner.invoke(cli, ["runs", "list", "--db", db])
+        assert result.exit_code == 0
+        assert "simple_workflow" in result.output
+
+    def test_runs_list_empty(self, runner, db) -> None:
+        result = runner.invoke(cli, ["runs", "list", "--db", db])
+        assert result.exit_code == 0
+        assert "No workflow runs found" in result.output
+
+    def test_runs_list_limit(self, runner, db, simple_wf_file) -> None:
+        for i in range(5):
+            runner.invoke(cli, ["run", simple_wf_file, f"--label", f"l{i}", "--db", db])
+        result = runner.invoke(cli, ["runs", "list", "--db", db, "-n", "2"])
+        assert result.exit_code == 0
+        assert "2 run(s)" in result.output
+
+    def test_runs_list_shows_status(self, runner, db, simple_wf_file, crashing_wf_file) -> None:
+        runner.invoke(cli, ["run", simple_wf_file, "--label", "ok", "--db", db])
+        runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        result = runner.invoke(cli, ["runs", "list", "--db", db])
+        assert "completed" in result.output
+        assert "failed" in result.output
+
+
+# ---------------------------------------------------------------------------
+# wf runs inspect
+# ---------------------------------------------------------------------------
+
+
+class TestCliRunsInspect:
+    def test_inspect_shows_all_steps(self, runner, db, simple_wf_file) -> None:
+        r = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        run_id = _run_id_from_output(r.output)
+        result = runner.invoke(cli, ["runs", "inspect", run_id, "--db", db])
+        assert result.exit_code == 0
+        assert "step_a" in result.output
+        assert "step_b" in result.output
+        assert "step_c" in result.output
+
+    def test_inspect_shows_error_on_failed_step(self, runner, db, crashing_wf_file) -> None:
+        runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        from workflow.engine import WorkflowEngine
+        with WorkflowEngine(db_path=db) as eng:
+            runs = eng.store.list_runs(limit=1)
+        run_id = runs[0].id
+        result = runner.invoke(cli, ["runs", "inspect", run_id, "--db", db])
+        assert "boom" in result.output
+        assert "RuntimeError" in result.output
+
+    def test_inspect_show_output_flag(self, runner, db, simple_wf_file) -> None:
+        r = runner.invoke(cli, ["run", simple_wf_file, "--label", "hi", "--db", db])
+        run_id = _run_id_from_output(r.output)
+        result = runner.invoke(
+            cli, ["runs", "inspect", run_id, "--db", db, "--show-output"]
+        )
+        assert result.exit_code == 0
+        assert "output" in result.output
+
+    def test_inspect_unknown_run_id(self, runner, db) -> None:
+        result = runner.invoke(cli, ["runs", "inspect", "no-such-id", "--db", db])
+        assert result.exit_code != 0
+
+    def test_inspect_all_steps_visible_after_resume(
+        self, runner, db, crashing_wf_file, fixed_wf_file
+    ) -> None:
+        """Acceptance criterion: crash, resume, inspect — all steps visible."""
+        # Crash
+        runner.invoke(cli, ["run", crashing_wf_file, "--label", "x", "--db", db])
+        from workflow.engine import WorkflowEngine
+        with WorkflowEngine(db_path=db) as eng:
+            runs = eng.store.list_runs(limit=1)
+        run_id = runs[0].id
+
+        # Resume
+        runner.invoke(cli, ["resume", run_id, "--db", db, "--workflow-file", fixed_wf_file])
+
+        # Inspect
+        result = runner.invoke(cli, ["runs", "inspect", run_id, "--db", db])
+        assert result.exit_code == 0
+        assert "step_a" in result.output
+        assert "step_b" in result.output
+        assert "step_c" in result.output
+        # Both the failed attempt and the successful retry are shown
+        assert "failed" in result.output
+        assert "completed" in result.output

--- a/workflow/cli.py
+++ b/workflow/cli.py
@@ -2,14 +2,99 @@
 
 Usage:
     uv run wf --help
-    uv run wf run <workflow_file> [--args ...]
+    uv run wf run examples/podcast_pipeline.py --episode-id ep-123
     uv run wf status <run_id>
     uv run wf resume <run_id>
     uv run wf runs list
     uv run wf runs inspect <run_id>
 """
 
+from __future__ import annotations
+
+import importlib.util
+import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
 import click
+
+from workflow.engine import WorkflowEngine, WorkflowError
+
+# ---------------------------------------------------------------------------
+# Colour / formatting helpers
+# ---------------------------------------------------------------------------
+
+_STATUS_COLOURS: dict[str, str] = {
+    "completed": "green",
+    "failed": "red",
+    "running": "yellow",
+    "pending": "cyan",
+}
+
+
+def _colourise(status: str) -> str:
+    colour = _STATUS_COLOURS.get(status, "white")
+    return click.style(status, fg=colour, bold=True)
+
+
+def _fmt_ts(ts: datetime | None) -> str:
+    if ts is None:
+        return "—"
+    return ts.strftime("%H:%M:%S")
+
+
+def _fmt_duration(started: datetime | None, finished: datetime | None) -> str:
+    if started is None or finished is None:
+        return "—"
+    delta = finished - started
+    secs = delta.total_seconds()
+    if secs < 60:
+        return f"{secs:.2f}s"
+    return f"{int(secs // 60)}m {int(secs % 60)}s"
+
+
+def _truncate(text: str, width: int = 60) -> str:
+    if len(text) <= width:
+        return text
+    return text[:width] + "…"
+
+
+def _short_id(run_id: str) -> str:
+    """Return the first 8 chars of a uuid4 for compact display."""
+    return run_id[:8]
+
+
+# ---------------------------------------------------------------------------
+# File loader — imports a workflow module from a .py path
+# ---------------------------------------------------------------------------
+
+
+def _load_workflow_module(path: str) -> Any:
+    """Import *path* as a module and return it."""
+    p = Path(path).resolve()
+    if not p.exists():
+        raise click.ClickException(f"File not found: {path}")
+    if not p.suffix == ".py":
+        raise click.ClickException(f"Expected a .py file, got: {path}")
+
+    spec = importlib.util.spec_from_file_location("_wf_module", p)
+    if spec is None or spec.loader is None:
+        raise click.ClickException(f"Cannot load module from: {path}")
+
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_wf_module"] = mod
+    try:
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    except Exception as exc:
+        raise click.ClickException(f"Error loading {path}: {exc}") from exc
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# CLI root
+# ---------------------------------------------------------------------------
 
 
 @click.group()
@@ -18,57 +103,358 @@ def cli() -> None:
     """Durable Workflow Engine — resumable, crash-safe workflow execution."""
 
 
-@cli.command()
+# ---------------------------------------------------------------------------
+# wf run
+# ---------------------------------------------------------------------------
+
+
+@cli.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
 @click.argument("workflow_file")
-@click.option("--db", default="~/.wf/runs.db", show_default=True, help="Path to the SQLite database.")
-def run(workflow_file: str, db: str) -> None:
-    """Run a workflow from WORKFLOW_FILE.
+@click.option("--db", default="~/.wf/runs.db", show_default=True, help="SQLite database path.")
+@click.pass_context
+def run(ctx: click.Context, workflow_file: str, db: str) -> None:
+    """Run a workflow defined in WORKFLOW_FILE.
 
-    WORKFLOW_FILE is a Python file that defines a @workflow-decorated function.
+    WORKFLOW_FILE must expose a WORKFLOW callable and optionally an
+    INPUT_SCHEMA dict mapping argument names to Python types.
+
+    Extra flags are forwarded as keyword arguments to the workflow function.
+    Use kebab-case flags: --episode-id becomes episode_id.
+
+    Example:
+
+        wf run examples/podcast_pipeline.py --episode-id ep-123
     """
-    click.echo(f"[wf] run: {workflow_file!r}  (db={db})")
-    click.echo("Not yet implemented — coming in a future issue.")
+    mod = _load_workflow_module(workflow_file)
+
+    func = getattr(mod, "WORKFLOW", None)
+    if func is None:
+        raise click.ClickException(
+            f"{workflow_file} must define a module-level WORKFLOW variable "
+            "pointing to the workflow function."
+        )
+
+    schema: dict[str, type] = getattr(mod, "INPUT_SCHEMA", {})
+
+    # Parse extra args into kwargs, converting types from INPUT_SCHEMA.
+    extra: list[str] = ctx.args
+    inputs: dict[str, Any] = {}
+    i = 0
+    while i < len(extra):
+        token = extra[i]
+        if token.startswith("--"):
+            key = token[2:].replace("-", "_")
+            if i + 1 < len(extra) and not extra[i + 1].startswith("--"):
+                raw_value = extra[i + 1]
+                i += 2
+            else:
+                raw_value = "true"
+                i += 1
+            # Coerce type if declared in INPUT_SCHEMA
+            target_type = schema.get(key, str)
+            try:
+                if target_type is bool:
+                    inputs[key] = raw_value.lower() not in ("false", "0", "no")
+                else:
+                    inputs[key] = target_type(raw_value)
+            except (ValueError, TypeError) as exc:
+                raise click.ClickException(
+                    f"Cannot convert --{key.replace('_', '-')} value {raw_value!r} "
+                    f"to {target_type.__name__}: {exc}"
+                )
+        else:
+            i += 1
+
+    with WorkflowEngine(db_path=db) as engine:
+        click.echo(
+            f"▶ Running {click.style(func.__name__, bold=True)}"
+            + (f" with {inputs}" if inputs else "")
+        )
+        try:
+            run_id = engine.run(func, **inputs)
+        except Exception as exc:
+            # Engine already persisted FAILED — surface a clean error.
+            runs = engine.store.list_runs(limit=1)
+            failed_id = runs[0].id if runs else "unknown"
+            click.echo(
+                click.style("✗ Workflow failed", fg="red", bold=True)
+                + f"  run_id={_short_id(failed_id)}…\n"
+                + click.style(str(exc), fg="red")
+            )
+            click.echo(f"\nInspect with:  wf runs inspect {failed_id}")
+            sys.exit(1)
+
+        click.echo(
+            click.style("✓ Completed", fg="green", bold=True)
+            + f"  run_id={click.style(run_id, bold=True)}"
+        )
+        click.echo(f"\nInspect with:  wf status {run_id}")
+
+
+# ---------------------------------------------------------------------------
+# wf status
+# ---------------------------------------------------------------------------
 
 
 @cli.command()
 @click.argument("run_id")
-@click.option("--db", default="~/.wf/runs.db", show_default=True, help="Path to the SQLite database.")
+@click.option("--db", default="~/.wf/runs.db", show_default=True, help="SQLite database path.")
 def status(run_id: str, db: str) -> None:
-    """Show status of a workflow run (per-step timing and result)."""
-    click.echo(f"[wf] status: {run_id!r}  (db={db})")
-    click.echo("Not yet implemented — coming in a future issue.")
+    """Show per-step status and timing for a workflow run."""
+    with WorkflowEngine(db_path=db) as engine:
+        try:
+            s = engine.status(run_id)
+        except WorkflowError as exc:
+            raise click.ClickException(str(exc))
+
+    run = s.run
+
+    # Run header
+    click.echo()
+    click.echo(f"  Workflow : {click.style(run.workflow_name, bold=True)}")
+    click.echo(f"  Run ID   : {run.id}")
+    click.echo(f"  Status   : {_colourise(run.status)}")
+    click.echo(f"  Started  : {_fmt_ts(run.created_at)}")
+    click.echo(
+        f"  Duration : {_fmt_duration(run.created_at, run.finished_at)}"
+    )
+    click.echo()
+
+    if not s.steps:
+        click.echo("  (no steps recorded)")
+        return
+
+    # Column widths
+    name_w = max(len(st.step_name) for st in s.steps)
+    name_w = max(name_w, 4)
+
+    # Header
+    header = (
+        f"  {'STEP':<{name_w}}  {'ATT':>3}  {'STATUS':<9}  "
+        f"{'STARTED':>8}  {'DURATION':>9}  {'CACHED':>6}"
+    )
+    click.echo(click.style(header, dim=True))
+    click.echo(click.style("  " + "─" * (len(header) - 2), dim=True))
+
+    for st in s.steps:
+        cached = "yes" if st.status == "completed" and st.attempt > 0 else ""
+        # A cache-hit has no started_at because it never ran again — infer from store
+        duration = _fmt_duration(st.started_at, st.finished_at)
+        click.echo(
+            f"  {st.step_name:<{name_w}}  {st.attempt:>3}  "
+            f"{_colourise(st.status):<9}  "
+            f"{_fmt_ts(st.started_at):>8}  {duration:>9}  {cached:>6}"
+        )
+        if st.status == "failed" and st.error:
+            first_line = st.error.strip().splitlines()[-1]
+            click.echo(
+                "  " + " " * name_w + "     "
+                + click.style(_truncate(first_line, 70), fg="red")
+            )
+
+    click.echo()
+
+
+# ---------------------------------------------------------------------------
+# wf resume
+# ---------------------------------------------------------------------------
 
 
 @cli.command()
 @click.argument("run_id")
-@click.option("--db", default="~/.wf/runs.db", show_default=True, help="Path to the SQLite database.")
-def resume(run_id: str, db: str) -> None:
-    """Resume a previously interrupted workflow run."""
-    click.echo(f"[wf] resume: {run_id!r}  (db={db})")
-    click.echo("Not yet implemented — coming in a future issue.")
+@click.option("--db", default="~/.wf/runs.db", show_default=True, help="SQLite database path.")
+@click.option(
+    "--workflow-file", "-f", default=None,
+    help="Path to the .py file defining the workflow (required when the function "
+         "was not run from the same process).",
+)
+def resume(run_id: str, db: str, workflow_file: str | None) -> None:
+    """Resume a previously interrupted workflow run.
+
+    Completed steps are skipped automatically via the step cache.
+
+    If the workflow function is not already registered (e.g. when resuming from
+    a fresh shell), pass --workflow-file to reload it:
+
+        wf resume <run_id> --workflow-file examples/podcast_pipeline.py
+    """
+    with WorkflowEngine(db_path=db) as engine:
+        try:
+            run_rec = engine.store.get_run(run_id)
+        except KeyError:
+            raise click.ClickException(f"No workflow run found with id {run_id!r}")
+
+        # Load + register the workflow function if a file was provided.
+        if workflow_file is not None:
+            mod = _load_workflow_module(workflow_file)
+            func = getattr(mod, "WORKFLOW", None)
+            if func is None:
+                raise click.ClickException(
+                    f"{workflow_file} must define a module-level WORKFLOW variable."
+                )
+            engine.register(func)
+
+        click.echo(
+            f"↺ Resuming {click.style(run_rec.workflow_name, bold=True)}"
+            f"  run_id={run_id}"
+        )
+        try:
+            engine.resume(run_id)
+        except WorkflowError as exc:
+            raise click.ClickException(str(exc))
+        except Exception as exc:
+            click.echo(
+                click.style("✗ Resume failed", fg="red", bold=True)
+                + f": {exc}"
+            )
+            click.echo(f"\nInspect with:  wf runs inspect {run_id}")
+            sys.exit(1)
+
+        click.echo(
+            click.style("✓ Completed", fg="green", bold=True)
+            + f"  run_id={click.style(run_id, bold=True)}"
+        )
+        click.echo(f"\nInspect with:  wf status {run_id}")
+
+
+# ---------------------------------------------------------------------------
+# wf runs list
+# ---------------------------------------------------------------------------
 
 
 @cli.group()
 def runs() -> None:
-    """Manage workflow runs."""
+    """Manage and inspect workflow runs."""
 
 
 @runs.command("list")
-@click.option("--db", default="~/.wf/runs.db", show_default=True, help="Path to the SQLite database.")
-@click.option("-n", "--limit", default=20, show_default=True, help="Maximum number of runs to show.")
+@click.option("--db", default="~/.wf/runs.db", show_default=True, help="SQLite database path.")
+@click.option("-n", "--limit", default=20, show_default=True, help="Maximum rows to show.")
 def runs_list(db: str, limit: int) -> None:
-    """List recent workflow runs."""
-    click.echo(f"[wf] runs list  (db={db}, limit={limit})")
-    click.echo("Not yet implemented — coming in a future issue.")
+    """List recent workflow runs, newest first.
+
+    Colour coding: green=completed  red=failed  yellow=running
+    """
+    with WorkflowEngine(db_path=db) as engine:
+        all_runs = engine.store.list_runs(limit=limit)
+
+    if not all_runs:
+        click.echo("No workflow runs found.")
+        return
+
+    click.echo()
+    header = f"  {'ID':>8}  {'WORKFLOW':<24}  {'STATUS':<9}  {'STARTED':>8}  {'DURATION':>9}"
+    click.echo(click.style(header, dim=True))
+    click.echo(click.style("  " + "─" * (len(header) - 2), dim=True))
+
+    for r in all_runs:
+        click.echo(
+            f"  {_short_id(r.id):>8}…  {r.workflow_name:<24}  "
+            f"{_colourise(r.status):<9}  "
+            f"{_fmt_ts(r.created_at):>8}  "
+            f"{_fmt_duration(r.created_at, r.finished_at):>9}"
+        )
+
+    click.echo()
+    click.echo(f"  Showing {len(all_runs)} run(s).  Full id: wf runs inspect <id>")
+    click.echo()
+
+
+# ---------------------------------------------------------------------------
+# wf runs inspect
+# ---------------------------------------------------------------------------
 
 
 @runs.command("inspect")
 @click.argument("run_id")
-@click.option("--db", default="~/.wf/runs.db", show_default=True, help="Path to the SQLite database.")
-def runs_inspect(run_id: str, db: str) -> None:
-    """Show a full step-by-step trace for a workflow run."""
-    click.echo(f"[wf] runs inspect: {run_id!r}  (db={db})")
-    click.echo("Not yet implemented — coming in a future issue.")
+@click.option("--db", default="~/.wf/runs.db", show_default=True, help="SQLite database path.")
+@click.option("--show-output", is_flag=True, default=False, help="Print pickled output repr.")
+def runs_inspect(run_id: str, db: str, show_output: bool) -> None:
+    """Show a full step-by-step execution trace for a workflow run.
+
+    Displays step name, attempt number, status, duration and — on failure —
+    the full error message.  Use --show-output to also print step outputs.
+    """
+    import pickle
+
+    with WorkflowEngine(db_path=db) as engine:
+        try:
+            s = engine.status(run_id)
+        except WorkflowError as exc:
+            raise click.ClickException(str(exc))
+
+    run = s.run
+    click.echo()
+    click.echo(f"  Workflow  : {click.style(run.workflow_name, bold=True)}")
+    click.echo(f"  Run ID    : {run.id}")
+    click.echo(f"  Status    : {_colourise(run.status)}")
+    click.echo(
+        f"  Started   : "
+        + (run.created_at.strftime("%Y-%m-%d %H:%M:%S") if run.created_at else "—")
+    )
+    click.echo(
+        f"  Finished  : "
+        + (run.finished_at.strftime("%Y-%m-%d %H:%M:%S") if run.finished_at else "—")
+    )
+    click.echo(
+        f"  Duration  : {_fmt_duration(run.created_at, run.finished_at)}"
+    )
+    click.echo()
+
+    if not s.steps:
+        click.echo("  (no steps recorded)")
+        click.echo()
+        return
+
+    for st in s.steps:
+        marker = {
+            "completed": click.style("✓", fg="green", bold=True),
+            "failed":    click.style("✗", fg="red",   bold=True),
+            "running":   click.style("⟳", fg="yellow", bold=True),
+            "pending":   click.style("·", fg="cyan"),
+        }.get(st.status, " ")
+
+        duration = _fmt_duration(st.started_at, st.finished_at)
+        click.echo(
+            f"  {marker} {click.style(st.step_name, bold=True)}"
+            f"  attempt={st.attempt}"
+            f"  status={_colourise(st.status)}"
+            f"  duration={duration}"
+        )
+
+        if show_output and st.output is not None:
+            try:
+                value = pickle.loads(st.output)
+                click.echo(
+                    "      output : "
+                    + click.style(_truncate(repr(value), 80), fg="cyan")
+                )
+            except Exception:
+                click.echo("      output : <unpickling failed>")
+
+        if st.error:
+            lines = st.error.strip().splitlines()
+            # Always show last line; show full traceback on inspect
+            click.echo(
+                "      error  : "
+                + click.style(_truncate(lines[-1], 80), fg="red")
+            )
+            if len(lines) > 1:
+                for line in lines[:-1]:
+                    click.echo(
+                        "               " + click.style(line, fg="red", dim=True)
+                    )
+
+        click.echo()
+
+    click.echo()
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Implements issue #7 — the full operator interface for managing workflow runs.

## Commands

### `wf run <file> [--key val …]`
- Loads `WORKFLOW` and `INPUT_SCHEMA` from a `.py` file
- Parses extra `--kebab-flags` as kwargs, type-coerced via `INPUT_SCHEMA`
- Runs via `WorkflowEngine`, prints the `run_id` on success
- Exits 1 on failure with the error message and an `inspect` hint

### `wf status <run_id>`
Table with: `STEP  ATT  STATUS  STARTED  DURATION  CACHED`
Inline error line on failed steps.

### `wf resume <run_id> [--workflow-file <path>]`
- Loads and registers the workflow function from `--workflow-file` (required for cross-process resume — the engine has no in-memory registry in a fresh shell)
- Resumes via the engine; completed steps are cache hits

### `wf runs list [-n N]`
Newest-first compact table with short id, workflow name, colour-coded status, duration.

### `wf runs inspect <run_id> [--show-output]`
Full trace: ✓/✗ markers per step, attempt number, duration, full traceback on failures, optional pickled output repr.

## Acceptance criterion — end-to-end demo

```
wf run examples/podcast_pipeline.py --episode-id ep-123
# ▶ Running process_podcast ...
# ✓ Completed  run_id=<id>

wf runs list
# completed  process_podcast  ...

wf status <id>
# STEP        ATT  STATUS    STARTED  DURATION
# download      0  completed ...
# transcribe    0  completed ...
# summarize     0  completed ...
# export        0  completed ...

# --- crash scenario ---
wf run /tmp/crash_wf.py --label hello
# ✗ Workflow failed ...

wf runs inspect <id>
# ✗ step_c  attempt=0  status=failed  ...  RuntimeError: simulated crash

wf resume <id> --workflow-file /tmp/fixed_wf.py
# ✓ Completed

wf runs inspect <id>
# ✓ step_a  (cached)
# ✓ step_b  (cached)
# ✗ step_c  attempt=0  failed  (original crash)
# ✓ step_c  attempt=1  completed  (resumed)
# ✓ step_d  completed
```

## Tests — 24/24 ✅, full suite 102/102 ✅

| Class | Coverage |
|---|---|
| `TestCliRun` | success, run_id printed, missing WORKFLOW, nonexistent file, failed exits 1, kebab→underscore |
| `TestCliStatus` | completed, all step names, timing column, unknown id, error inline |
| `TestCliResume` | completes run, no-file raises, unknown id, completed steps skipped |
| `TestCliRunsList` | shows run, empty message, limit, both statuses shown |
| `TestCliRunsInspect` | all steps, error message, `--show-output`, unknown id, full crash→resume→inspect |

Closes #7